### PR TITLE
Fix missing closing Box tag in prompt editor

### DIFF
--- a/claude-workflow-manager/frontend/src/components/OrchestrationDesignerPage.tsx
+++ b/claude-workflow-manager/frontend/src/components/OrchestrationDesignerPage.tsx
@@ -3151,8 +3151,9 @@ Format your response as JSON:
               </Box>
             )}
           </Box>
+        </Box>
+        {/* End Main Content Area */}
       </Box>
-      {/* End Main Content Area */}
 
       {/* Configuration Drawer */}
       <Drawer


### PR DESCRIPTION
Added missing closing Box tag for the wrapper element containing the prompt editor and canvas.