### PR TITLE
Fix: Remove prompt content truncation in auto-generated orchestrations

### DIFF
--- a/claude-workflow-manager/frontend/src/components/OrchestrationDesignerPage.tsx
+++ b/claude-workflow-manager/frontend/src/components/OrchestrationDesignerPage.tsx
@@ -285,7 +285,7 @@ const OrchestrationDesignerPage: React.FC = () => {
                   agents: [{
                     id: `agent-${sequenceIndex}-0`,
                     name: prompt.description.replace(/-/g, ' ').replace(/_/g, ' '),
-                    system_prompt: `Execute the following prompt:\n\n${prompt.content.substring(0, 500)}...`,
+                    system_prompt: `Execute the following prompt:\n\n${prompt.content}`,
                     role: 'worker' as AgentRole,
                   }],
                   task: `Execute prompt: ${prompt.filename}`,
@@ -319,7 +319,7 @@ const OrchestrationDesignerPage: React.FC = () => {
                   agents: sequenceGroup.map((prompt: any, idx: number) => ({
                     id: `agent-${sequenceIndex}-${idx}`,
                     name: `${prompt.parallel}: ${prompt.description.replace(/-/g, ' ').replace(/_/g, ' ')}`,
-                    system_prompt: `Execute the following prompt:\n\n${prompt.content.substring(0, 500)}...`,
+                    system_prompt: `Execute the following prompt:\n\n${prompt.content}`,
                     role: 'worker' as AgentRole,
                   })),
                   task: `Execute parallel prompts in sequence ${sequenceGroup[0].sequence}`,


### PR DESCRIPTION
## Summary

Fixed an issue where auto-generated orchestration designs had truncated prompt content, showing only the first 500 characters followed by "...".

## Problem

When using the auto-generate orchestration feature (magic wand icon on workflow cards), the system prompts for agents were being truncated to 500 characters. This meant:
- Users couldn't see the full prompt content in the Monaco editor
- The orchestration would execute with incomplete prompts
- No way to access the full original prompt text

## Solution

Removed the `.substring(0, 500)...` truncation from both code paths:
1. **Sequential block generation** - for single prompts
2. **Parallel block generation** - for multiple parallel prompts

### Changes

**OrchestrationDesignerPage.tsx** (lines 288 and 322):

Before:
```typescript
system_prompt: `Execute the following prompt:\n\n${prompt.content.substring(0, 500)}...`
```

After:
```typescript
system_prompt: `Execute the following prompt:\n\n${prompt.content}`
```

## Benefits

- Full prompt content now available in Monaco editor
- Users can see and edit complete prompts
- Orchestrations execute with the full, correct prompts
- Better UX - no confusing truncation

## Testing

To test:
1. Create a workflow with prompts in `.clode/claude_prompts/` folder
2. Click the magic wand icon (Auto-Generate Orchestration)
3. Click on an agent's system prompt to open Monaco editor
4. Verify the full prompt content is visible (no "..." truncation)