### PR TITLE
Add code editor quick access from workflows page

### DIFF
--- a/claude-workflow-manager/frontend/src/components/NewCodeEditorPage.tsx
+++ b/claude-workflow-manager/frontend/src/components/NewCodeEditorPage.tsx
@@ -445,23 +445,45 @@ const NewCodeEditorPage: React.FC = () => {
     loadOrchestrationDesigns();
     loadAvailableModels();
     configureMonacoThemes();
-    
+
     // Apply default vs-dark theme colors on mount
-    applyThemeColors('vs-dark', { 
-      colors: { 
-        'editor.background': '#1e1e1e', 
-        'editor.foreground': '#d4d4d4', 
-        'sideBar.background': '#252526', 
-        'activityBar.background': '#333333', 
-        'statusBar.background': '#007acc', 
-        'titleBar.activeBackground': '#3c3c3c' 
-      } 
+    applyThemeColors('vs-dark', {
+      colors: {
+        'editor.background': '#1e1e1e',
+        'editor.foreground': '#d4d4d4',
+        'sideBar.background': '#252526',
+        'activityBar.background': '#333333',
+        'statusBar.background': '#007acc',
+        'titleBar.activeBackground': '#3c3c3c'
+      }
     });
-    
+
     return () => {
       stopChangesPolling();
     };
   }, []);
+
+  // Handle URL parameters for pre-selecting workflow and branch
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const workflowId = params.get('workflow');
+    const branch = params.get('branch');
+
+    if (workflowId && workflows.length > 0) {
+      const workflow = workflows.find(w => w.id === workflowId);
+      if (workflow && workflowId !== selectedWorkflow) {
+        handleWorkflowChange(workflowId);
+
+        // If a branch is specified and different from current, set it after workflow loads
+        if (branch) {
+          // Set branch after a short delay to ensure workflow is initialized
+          setTimeout(() => {
+            setSelectedBranch(branch);
+          }, 500);
+        }
+      }
+    }
+  }, [location.search, workflows]);
   
   // Auto-scroll chat to bottom
   useEffect(() => {

--- a/claude-workflow-manager/frontend/src/components/WorkflowsPage.tsx
+++ b/claude-workflow-manager/frontend/src/components/WorkflowsPage.tsx
@@ -24,7 +24,7 @@ import {
 import {
   Add, PlayArrow, FolderOpen, SmartToy, Delete,
   CheckCircle, Error, Warning, VpnKey, DesignServices,
-  AutoFixHigh
+  AutoFixHigh, Code
 } from '@mui/icons-material';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
@@ -269,6 +269,14 @@ const WorkflowsPage: React.FC = () => {
                 >
                   View Agents
                 </Button>
+                <IconButton
+                  size="small"
+                  onClick={() => navigate(`/code-editor?workflow=${workflow.id}&branch=${workflow.branch}`)}
+                  title="Open in Code Editor"
+                  color="primary"
+                >
+                  <Code />
+                </IconButton>
                 <IconButton
                   size="small"
                   onClick={() => navigate(`/design?workflow=${workflow.id}`)}


### PR DESCRIPTION
## Summary
- Add Code icon button to each workflow card for direct access to code editor
- Implement URL parameter support (workflow & branch) in NewCodeEditorPage
- Auto-initialize editor with preselected workflow and branch when accessed via URL
- Enables seamless one-click navigation from workflows page to code editor

## Changes
- **WorkflowsPage.tsx**: Added Code icon button that navigates to code editor with workflow ID and branch in URL
- **NewCodeEditorPage.tsx**: Added useEffect hook to read URL parameters and auto-select workflow/branch

## How It Works
1. User clicks Code icon on a workflow card
2. Navigates to /code-editor?workflow={id}&branch={branch}
3. Editor automatically loads the workflow and selects the specified branch
4. Ready to start editing immediately

## Test Plan
- [x] Code changes compile without errors
- [ ] Click Code icon on workflow card navigates to editor
- [ ] Editor pre-selects correct workflow and branch
- [ ] File tree loads for the selected repository
