### PR TITLE
Fix overlapping text in Spawn Agent modal dropdown

### DIFF
--- a/claude-workflow-manager/frontend/src/components/AgentsPage.tsx
+++ b/claude-workflow-manager/frontend/src/components/AgentsPage.tsx
@@ -314,6 +314,7 @@ const AgentsPage: React.FC = () => {
             <Select
               value={selectedPromptId}
               onChange={(e) => setSelectedPromptId(e.target.value)}
+              label="Select Prompt"
               displayEmpty
               renderValue={(selected) => {
                 if (selected === '') {


### PR DESCRIPTION
## Issue
When clicking the 'Spawn Agent' button on the Agents page, the modal shows a dropdown with overlapping text that's unreadable. The 'Select Prompt' label overlaps with the selected value text.

## Root Cause
The Select component was missing the `label` prop, which prevented Material-UI from properly handling label positioning. Without this prop, the InputLabel doesn't know to shrink and move when a value is selected.

## Solution
Added `label="Select Prompt"` prop to the Select component to match the InputLabel text. This ensures Material-UI properly handles the label state transitions:
- When empty: Label is in default position
- When focused or has value: Label shrinks and moves to top
- Prevents overlap with selected value text

## Changes
- **AgentsPage.tsx** (line 317): Added `label="Select Prompt"` prop to Select component

## Testing
- [x] Code compiles without errors
- [ ] Spawn Agent modal opens correctly
- [ ] Dropdown label is readable and doesn't overlap
- [ ] Label shrinks when value is selected
- [ ] Label returns to default when cleared

## Before
Label overlaps with selected value, making text unreadable

## After
Label properly shrinks and positions above the dropdown when value is selected
