### PR TITLE
Fix label overlapping value in Spawn Agent dropdown on initial render

### DIFF
--- a/claude-workflow-manager/frontend/src/components/AgentsPage.tsx
+++ b/claude-workflow-manager/frontend/src/components/AgentsPage.tsx
@@ -310,12 +310,13 @@ const AgentsPage: React.FC = () => {
         <DialogTitle>Spawn New Agent</DialogTitle>
         <DialogContent>
           <FormControl fullWidth sx={{ mt: 2 }}>
-            <InputLabel>Select Prompt</InputLabel>
+            <InputLabel shrink>Select Prompt</InputLabel>
             <Select
               value={selectedPromptId}
               onChange={(e) => setSelectedPromptId(e.target.value)}
               label="Select Prompt"
               displayEmpty
+              notched
               renderValue={(selected) => {
                 if (selected === '') {
                   return <em>No prompt (interactive mode)</em>;


### PR DESCRIPTION
## Issue
After the previous fix (PR #433), the label still overlaps with the dropdown value on initial page load. The label only moves to the correct position after clicking on the dropdown.

## Root Cause
When using `displayEmpty` with a custom `renderValue`, Material-UI's InputLabel doesn't automatically detect that content is being rendered and doesn't shrink the label. The `renderValue` function always returns content (either "No prompt (interactive mode)" or a prompt name), but the InputLabel doesn't know this.

## Solution
1. Added `shrink` prop to InputLabel - forces the label to always stay in the shrunk position at the top
2. Added `notched` prop to Select - ensures the outline has a proper notch for the label

This ensures the label is always positioned correctly, even on initial render.

## Changes
- **AgentsPage.tsx** (line 313): Added `shrink` prop to InputLabel
- **AgentsPage.tsx** (line 319): Added `notched` prop to Select

## Technical Details
When using Material-UI Select with:
- `displayEmpty={true}` - allows showing content when value is empty
- `renderValue={}` - custom rendering of the selected value

The InputLabel cannot auto-detect the presence of content. We must manually control the shrink state.

## Testing
- [x] Code compiles without errors
- [ ] Label is positioned at top on initial render
- [ ] Label stays at top when selecting values
- [ ] No overlap between label and dropdown value
- [ ] Outline has proper notch for label

## Before
Label overlaps with "No prompt (interactive mode)" text until user clicks the dropdown

## After
Label is always properly positioned at the top of the field with no overlap
