### PR TITLE
Register voice and image MCP servers in Claude agent configuration

### DIFF
--- a/claude-workflow-manager/backend/claude_mcp_config.json
+++ b/claude-workflow-manager/backend/claude_mcp_config.json
@@ -4,6 +4,16 @@
       "command": "nc",
       "args": ["claude-workflow-mcp", "8002"],
       "description": "Claude Workflow Manager - Access workflows, orchestration patterns, and multi-agent tools"
+    },
+    "voice-interaction": {
+      "command": "nc",
+      "args": ["claude-workflow-voice-mcp-http", "8001"],
+      "description": "Voice Interaction - Speech-to-text and text-to-speech capabilities using Whisper and Picovoice Orca"
+    },
+    "image-processing": {
+      "command": "nc",
+      "args": ["claude-workflow-image-mcp-http", "8002"],
+      "description": "Image Processing - OCR and document text extraction using Google Cloud Vision API"
     }
   }
 }

--- a/claude-workflow-manager/backend/mcp_config.json
+++ b/claude-workflow-manager/backend/mcp_config.json
@@ -4,6 +4,16 @@
       "command": "nc",
       "args": ["YOUR_SERVER_IP", "8002"],
       "cwd": "/tmp"
+    },
+    "voice-interaction": {
+      "command": "nc",
+      "args": ["YOUR_SERVER_IP", "14302"],
+      "cwd": "/tmp"
+    },
+    "image-processing": {
+      "command": "nc",
+      "args": ["YOUR_SERVER_IP", "14402"],
+      "cwd": "/tmp"
     }
   }
 }


### PR DESCRIPTION
## Summary

Enables Claude agents to access voice interaction and image processing capabilities by registering the voice and image MCP servers in the agent MCP configuration.

## Changes

- **Updated ** (internal Docker network configuration)
  - Added voice-interaction MCP server (claude-workflow-voice-mcp-http:8001)
  - Added image-processing MCP server (claude-workflow-image-mcp-http:8002)
  
- **Updated ** (external access template)
  - Added voice-interaction MCP server (YOUR_SERVER_IP:14302)
  - Added image-processing MCP server (YOUR_SERVER_IP:14402)

## Tools Now Available to Claude Agents

### Voice Interaction Tools (4 tools)
1. `transcribe_audio` - Speech-to-text using Whisper
2. `synthesize_speech` - Text-to-speech using Picovoice Orca
3. `voice_conversation` - Complete voice interaction loop
4. `check_voice_api_health` - Health monitoring

### Image Processing Tools (4 tools)
1. `extract_text_from_image` - OCR for base64 images
2. `extract_text_from_url` - Process images/PDFs from URLs
3. `extract_text_from_pdf` - Multi-page PDF processing
4. `check_image_api_health` - Health monitoring

## Impact

- **Multi-modal agents**: Agents can now combine voice, vision, and text capabilities
- **Voice workflows**: Enable speech-to-text and text-to-speech in orchestrations
- **Document processing**: Agents can extract text from images and PDFs
- **No code changes required**: Configuration is automatically copied to new instances

## How It Works

The `claude_manager.py` automatically copies `claude_mcp_config.json` to `.mcp.json` in each Claude instance's working directory. New instances will automatically have access to all three MCP servers.

## Testing

After deployment, verify MCP servers are accessible:

```bash
# Check voice MCP server
curl http://192.168.1.92:14302/health

# Check image MCP server  
curl http://192.168.1.92:14402/health
```

Then test in a Claude agent orchestration to confirm tools are discoverable.

## Related

- Voice backend/MCP deployed in previous work
- Image backend/MCP deployed in #438