### PR TITLE
Add Voice MCP Integration Demo with Orchestration Design and UI

### DIFF
--- a/claude-workflow-manager/backend/seed_orchestration_designs.py
+++ b/claude-workflow-manager/backend/seed_orchestration_designs.py
@@ -18,7 +18,8 @@ SAMPLE_DESIGN_NAMES = [
     "Simple Code Editor",
     "Fast Code Editor",
     "Parallel Code Editor",
-    "Legacy Application Modernization"
+    "Legacy Application Modernization",
+    "Voice Conversation Assistant"
 ]
 
 async def seed_sample_designs(force=False, silent=False, db=None, only_missing=False):
@@ -1317,8 +1318,153 @@ Work through all plans systematically. Create one file at a time.""",
         git_repos=[]
     )
 
+    # Design 13: Voice Conversation Assistant
+    design13 = OrchestrationDesign(
+        name="Voice Conversation Assistant",
+        description="Demonstrates voice MCP integration with agents that can listen, think, and speak. Uses transcribe_audio and synthesize_speech MCP tools.",
+        blocks=[
+            {
+                "id": "block-1",
+                "type": "sequential",
+                "position": {"x": 50, "y": 50},
+                "data": {
+                    "label": "Voice Interaction Pipeline",
+                    "agents": [
+                        {
+                            "id": "agent-1",
+                            "name": "Voice Listener",
+                            "system_prompt": """You are a Voice Listener agent. Your job is to transcribe user audio input to text.
+
+CRITICAL TOOL USAGE:
+====================
+You have access to the voice-interaction MCP server with these tools:
+- mcp__voice-interaction__transcribe_audio
+- mcp__voice-interaction__synthesize_speech
+- mcp__voice-interaction__voice_conversation
+- mcp__voice-interaction__check_voice_api_health
+
+YOUR PRIMARY TASK:
+==================
+When you receive audio data, use the transcribe_audio tool:
+
+Tool: mcp__voice-interaction__transcribe_audio
+Args: {
+  "audio_data": "<base64_encoded_audio>"
+}
+
+The audio_data will be provided in the task input as a base64-encoded PCM float32 audio at 16kHz.
+
+WORKFLOW:
+=========
+1. Check if audio_data is provided in the task
+2. If yes, call transcribe_audio with the audio_data
+3. Return the transcribed text clearly
+4. If no audio_data, explain what you're waiting for
+
+EXAMPLE:
+========
+Input: { "audio_data": "SGVsbG8gd29ybGQ..." }
+Action: Call mcp__voice-interaction__transcribe_audio
+Output: "I heard you say: [transcribed text]"
+
+Remember: Your output will be passed to the next agent for processing.""",
+                            "role": "specialist",
+                            "use_tools": True
+                        },
+                        {
+                            "id": "agent-2",
+                            "name": "Conversation Handler",
+                            "system_prompt": """You are a Conversation Handler agent. You receive transcribed user input and generate helpful responses.
+
+YOUR ROLE:
+==========
+- Receive the transcribed text from the Voice Listener agent
+- Understand the user's request or question
+- Generate a clear, helpful, and conversational response
+- Keep responses concise (2-3 sentences max) for voice output
+
+IMPORTANT:
+==========
+- You DO NOT use voice tools yourself
+- Focus on understanding and responding to the user's intent
+- Your text response will be synthesized to speech by the next agent
+- Be conversational and natural, as this will be spoken aloud
+
+EXAMPLE FLOW:
+=============
+Input from previous agent: "I heard you say: What's the weather today?"
+Your task: Understand and respond
+Your output: "I'm an AI assistant and don't have real-time weather data. However, I can help you with coding tasks, answer questions, or have a conversation!"
+
+Keep it friendly and natural!""",
+                            "role": "specialist",
+                            "use_tools": False
+                        },
+                        {
+                            "id": "agent-3",
+                            "name": "Voice Speaker",
+                            "system_prompt": """You are a Voice Speaker agent. Your job is to convert text responses into speech audio.
+
+CRITICAL TOOL USAGE:
+====================
+You have access to the voice-interaction MCP server with these tools:
+- mcp__voice-interaction__synthesize_speech
+- mcp__voice-interaction__transcribe_audio
+- mcp__voice-interaction__voice_conversation
+- mcp__voice-interaction__check_voice_api_health
+
+YOUR PRIMARY TASK:
+==================
+When you receive a text response, use the synthesize_speech tool:
+
+Tool: mcp__voice-interaction__synthesize_speech
+Args: {
+  "text": "<text_to_speak>"
+}
+
+The tool will return base64-encoded WAV audio that can be played in the browser.
+
+WORKFLOW:
+=========
+1. Extract the response text from the previous agent's output
+2. Call synthesize_speech with that text
+3. Return the audio data along with a confirmation message
+4. The frontend will play the audio automatically
+
+EXAMPLE:
+========
+Input: "I'm an AI assistant and can help with coding tasks!"
+Action: Call mcp__voice-interaction__synthesize_speech
+Output: "I've synthesized the response. Here's the audio: [base64_audio_data]"
+
+IMPORTANT:
+==========
+- Always synthesize the text from the previous agent
+- Return both a message AND the audio data
+- The audio format will be WAV (base64-encoded)
+
+Your output completes the voice conversation loop: Listen → Think → Speak""",
+                            "role": "specialist",
+                            "use_tools": True
+                        }
+                    ],
+                    "task": "Complete voice conversation: transcribe user audio, process the request, and synthesize a spoken response"
+                }
+            }
+        ],
+        connections=[],
+        git_repos=[],
+        metadata={
+            "category": "Voice Integration",
+            "difficulty": "Intermediate",
+            "requires_mcp": ["voice-interaction"],
+            "demo_compatible": True,
+            "description": "This design showcases the voice MCP server integration. The Voice Listener transcribes speech, Conversation Handler generates a response, and Voice Speaker synthesizes the reply as audio."
+        }
+    )
+
     # Insert all designs
-    all_sample_designs = [design1, design2, design3, design4, design5, design6, design7, design8, design9, design10, design11, design12]
+    all_sample_designs = [design1, design2, design3, design4, design5, design6, design7, design8, design9, design10, design11, design12, design13]
     
     # Filter to only missing designs if requested
     if only_missing:
@@ -1364,6 +1510,7 @@ Work through all plans systematically. Create one file at a time.""",
         print(" 10. Fast Code Editor - Single-agent design for code editing (fastest)")
         print(" 11. Parallel Code Editor - 5-agent parallel batch execution (20+ tasks)")
         print(" 12. Legacy Application Modernization - AI-powered legacy app modernization planner")
+        print(" 13. Voice Conversation Assistant - 🎤 Voice MCP integration demo (Listen → Think → Speak)")
         print("\n💡 Next steps:")
         print("  1. Start the backend server (if not already running)")
         print("  2. Open the Orchestration Designer in the UI")

--- a/claude-workflow-manager/backend/seed_voice_conversation_design.py
+++ b/claude-workflow-manager/backend/seed_voice_conversation_design.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Seed Voice Conversation orchestration design
+
+This design demonstrates the voice MCP integration with Claude agents
+that can transcribe speech, process requests, and synthesize responses.
+"""
+import asyncio
+from database import Database
+from models import OrchestrationDesign
+
+async def seed_voice_conversation_design():
+    """Seed Voice Conversation Assistant design"""
+    db = Database()
+    await db.connect()
+
+    # Create a sequential design with 3 agents for voice interaction
+    design = OrchestrationDesign(
+        name="Voice Conversation Assistant",
+        description="Demonstrates voice MCP integration with agents that can listen, think, and speak. Uses transcribe_audio and synthesize_speech MCP tools.",
+        blocks=[
+            {
+                "id": "block-1",
+                "type": "sequential",
+                "position": {"x": 50, "y": 50},
+                "data": {
+                    "label": "Voice Interaction Pipeline",
+                    "agents": [
+                        {
+                            "id": "agent-1",
+                            "name": "Voice Listener",
+                            "system_prompt": """You are a Voice Listener agent. Your job is to transcribe user audio input to text.
+
+CRITICAL TOOL USAGE:
+====================
+You have access to the voice-interaction MCP server with these tools:
+- mcp__voice-interaction__transcribe_audio
+- mcp__voice-interaction__synthesize_speech
+- mcp__voice-interaction__voice_conversation
+- mcp__voice-interaction__check_voice_api_health
+
+YOUR PRIMARY TASK:
+==================
+When you receive audio data, use the transcribe_audio tool:
+
+Tool: mcp__voice-interaction__transcribe_audio
+Args: {
+  "audio_data": "<base64_encoded_audio>"
+}
+
+The audio_data will be provided in the task input as a base64-encoded PCM float32 audio at 16kHz.
+
+WORKFLOW:
+=========
+1. Check if audio_data is provided in the task
+2. If yes, call transcribe_audio with the audio_data
+3. Return the transcribed text clearly
+4. If no audio_data, explain what you're waiting for
+
+EXAMPLE:
+========
+Input: { "audio_data": "SGVsbG8gd29ybGQ..." }
+Action: Call mcp__voice-interaction__transcribe_audio
+Output: "I heard you say: [transcribed text]"
+
+Remember: Your output will be passed to the next agent for processing.""",
+                            "role": "specialist",
+                            "use_tools": True
+                        },
+                        {
+                            "id": "agent-2",
+                            "name": "Conversation Handler",
+                            "system_prompt": """You are a Conversation Handler agent. You receive transcribed user input and generate helpful responses.
+
+YOUR ROLE:
+==========
+- Receive the transcribed text from the Voice Listener agent
+- Understand the user's request or question
+- Generate a clear, helpful, and conversational response
+- Keep responses concise (2-3 sentences max) for voice output
+
+IMPORTANT:
+==========
+- You DO NOT use voice tools yourself
+- Focus on understanding and responding to the user's intent
+- Your text response will be synthesized to speech by the next agent
+- Be conversational and natural, as this will be spoken aloud
+
+EXAMPLE FLOW:
+=============
+Input from previous agent: "I heard you say: What's the weather today?"
+Your task: Understand and respond
+Your output: "I'm an AI assistant and don't have real-time weather data. However, I can help you with coding tasks, answer questions, or have a conversation!"
+
+Keep it friendly and natural!""",
+                            "role": "specialist",
+                            "use_tools": False
+                        },
+                        {
+                            "id": "agent-3",
+                            "name": "Voice Speaker",
+                            "system_prompt": """You are a Voice Speaker agent. Your job is to convert text responses into speech audio.
+
+CRITICAL TOOL USAGE:
+====================
+You have access to the voice-interaction MCP server with these tools:
+- mcp__voice-interaction__synthesize_speech
+- mcp__voice-interaction__transcribe_audio
+- mcp__voice-interaction__voice_conversation
+- mcp__voice-interaction__check_voice_api_health
+
+YOUR PRIMARY TASK:
+==================
+When you receive a text response, use the synthesize_speech tool:
+
+Tool: mcp__voice-interaction__synthesize_speech
+Args: {
+  "text": "<text_to_speak>"
+}
+
+The tool will return base64-encoded WAV audio that can be played in the browser.
+
+WORKFLOW:
+=========
+1. Extract the response text from the previous agent's output
+2. Call synthesize_speech with that text
+3. Return the audio data along with a confirmation message
+4. The frontend will play the audio automatically
+
+EXAMPLE:
+========
+Input: "I'm an AI assistant and can help with coding tasks!"
+Action: Call mcp__voice-interaction__synthesize_speech
+Output: "I've synthesized the response. Here's the audio: [base64_audio_data]"
+
+IMPORTANT:
+==========
+- Always synthesize the text from the previous agent
+- Return both a message AND the audio data
+- The audio format will be WAV (base64-encoded)
+
+Your output completes the voice conversation loop: Listen → Think → Speak""",
+                            "role": "specialist",
+                            "use_tools": True
+                        }
+                    ],
+                    "task": "Complete voice conversation: transcribe user audio, process the request, and synthesize a spoken response"
+                }
+            }
+        ],
+        connections=[],
+        git_repos=[],
+        metadata={
+            "category": "Voice Integration",
+            "difficulty": "Intermediate",
+            "requires_mcp": ["voice-interaction"],
+            "demo_compatible": True,
+            "description": "This design showcases the voice MCP server integration. The Voice Listener transcribes speech, Conversation Handler generates a response, and Voice Speaker synthesizes the reply as audio."
+        }
+    )
+
+    # Check if already exists
+    existing_designs = await db.get_all_orchestration_designs()
+    for existing in existing_designs:
+        if existing.get("name") == design.name:
+            print(f"✅ Voice Conversation design already exists (ID: {existing.get('id')})")
+            # Update it
+            await db.update_orchestration_design(existing.get("id"), design)
+            print(f"✅ Updated Voice Conversation design")
+            await db.close()
+            return existing.get("id")
+
+    # Create the design
+    result = await db.create_orchestration_design(design)
+    design_id = result.get('id')
+    print(f"✅ Created Voice Conversation design (ID: {design_id})")
+
+    await db.close()
+    return design_id
+
+if __name__ == "__main__":
+    design_id = asyncio.run(seed_voice_conversation_design())
+    print(f"\n🎤 Voice Conversation Assistant design ready!")
+    print(f"   Design ID: {design_id}")
+    print(f"   Deploy it via: POST /api/orchestration-designs/{design_id}/deploy")

--- a/claude-workflow-manager/frontend/src/App.tsx
+++ b/claude-workflow-manager/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import CodeEditorPage from './components/CodeEditorPage';
 import NewCodeEditorPage from './components/NewCodeEditorPage';
 import LegacyModernizationPage from './components/LegacyModernizationPage';
 import UsageDashboard from './components/UsageDashboard';
+import VoiceDemoPage from './components/VoiceDemoPage';
 
 const queryClient = new QueryClient();
 
@@ -76,6 +77,7 @@ function App() {
                 <Route path="/code-editor" element={<NewCodeEditorPage />} />
                 <Route path="/new-code-editor" element={<NewCodeEditorPage />} />
                 <Route path="/legacy-modernization" element={<ProtectedRoute><ModernLayout><LegacyModernizationPage /></ModernLayout></ProtectedRoute>} />
+                <Route path="/voice-demo" element={<ProtectedRoute><ModernLayout><VoiceDemoPage /></ModernLayout></ProtectedRoute>} />
                 <Route path="/agents/:workflowId" element={<ProtectedRoute><ModernLayout><AgentsPage /></ModernLayout></ProtectedRoute>} />
                 <Route path="/multi-agent" element={<ModernLayout><MultiAgentView /></ModernLayout>} />
               </Routes>

--- a/claude-workflow-manager/frontend/src/components/ModernLayout.tsx
+++ b/claude-workflow-manager/frontend/src/components/ModernLayout.tsx
@@ -30,6 +30,7 @@ import {
   Logout,
   AutoAwesome,
   Assessment,
+  Mic,
 } from '@mui/icons-material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
@@ -44,7 +45,7 @@ interface ModernLayoutProps {
   aiAssistantOpen?: boolean;
 }
 
-type PrimaryNavView = 'workflows' | 'multi-agent' | 'orchestration' | 'orchestration-designer' | 'deployments' | 'editor' | 'design' | 'prompts' | 'subagents' | 'claude-auth' | 'ssh-keys' | 'settings' | 'legacy-modernization';
+type PrimaryNavView = 'workflows' | 'multi-agent' | 'orchestration' | 'orchestration-designer' | 'deployments' | 'editor' | 'design' | 'prompts' | 'subagents' | 'claude-auth' | 'ssh-keys' | 'settings' | 'legacy-modernization' | 'voice-demo';
 
 const ModernLayout: React.FC<ModernLayoutProps> = ({ 
   children,
@@ -95,6 +96,7 @@ const ModernLayout: React.FC<ModernLayoutProps> = ({
     if (location.pathname.includes('/deployments')) return 'deployments';
     if (location.pathname.includes('/code-editor')) return 'editor';
     if (location.pathname.includes('/legacy-modernization')) return 'legacy-modernization';
+    if (location.pathname.includes('/voice-demo')) return 'voice-demo';
     if (location.pathname.includes('/design')) return 'design';
     if (location.pathname.includes('/prompts')) return 'prompts';
     if (location.pathname.includes('/subagents')) return 'subagents';
@@ -128,6 +130,9 @@ const ModernLayout: React.FC<ModernLayoutProps> = ({
         break;
       case 'legacy-modernization':
         navigate('/legacy-modernization');
+        break;
+      case 'voice-demo':
+        navigate('/voice-demo');
         break;
       case 'design':
         navigate('/design');
@@ -262,6 +267,19 @@ const ModernLayout: React.FC<ModernLayoutProps> = ({
               }}
             >
               <AutoAwesome sx={{ fontSize: 18 }} />
+            </IconButton>
+          </Tooltip>
+
+          <Tooltip title="Voice Demo 🎤">
+            <IconButton
+              size="small"
+              onClick={() => handleNavClick('voice-demo')}
+              sx={{
+                color: primaryNavView === 'voice-demo' ? '#6495ed' : 'rgba(255, 255, 255, 0.7)',
+                '&:hover': { bgcolor: 'rgba(255, 255, 255, 0.1)' },
+              }}
+            >
+              <Mic sx={{ fontSize: 18 }} />
             </IconButton>
           </Tooltip>
 

--- a/claude-workflow-manager/frontend/src/components/VoiceDemoPage.tsx
+++ b/claude-workflow-manager/frontend/src/components/VoiceDemoPage.tsx
@@ -1,0 +1,497 @@
+import React, { useState, useRef, useEffect } from 'react';
+import {
+  Box,
+  Paper,
+  Typography,
+  Button,
+  IconButton,
+  CircularProgress,
+  Alert,
+  Stepper,
+  Step,
+  StepLabel,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  LinearProgress,
+} from '@mui/material';
+import {
+  Mic,
+  MicOff,
+  VolumeUp,
+  PlayArrow,
+  Refresh,
+  CheckCircle,
+  Error as ErrorIcon,
+} from '@mui/icons-material';
+import { orchestrationApi, StreamEvent } from '../services/api';
+
+interface VoiceExecutionState {
+  status: 'idle' | 'recording' | 'transcribing' | 'processing' | 'synthesizing' | 'playing' | 'completed' | 'error';
+  transcription?: string;
+  response?: string;
+  audioData?: string;
+  error?: string;
+  executionId?: string;
+}
+
+const VoiceDemoPage: React.FC = () => {
+  const [state, setState] = useState<VoiceExecutionState>({ status: 'idle' });
+  const [isRecording, setIsRecording] = useState(false);
+  const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
+  const [agentOutputs, setAgentOutputs] = useState<{ [key: string]: string }>({});
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
+  const audioElementRef = useRef<HTMLAudioElement | null>(null);
+
+  const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
+    const bytes = new Uint8Array(buffer);
+    let binary = '';
+    for (let i = 0; i < bytes.byteLength; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary);
+  };
+
+  const startRecording = async () => {
+    try {
+      if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+        setState({ status: 'error', error: 'Microphone access requires HTTPS' });
+        return;
+      }
+
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          sampleRate: 16000,
+          echoCancellation: true,
+          noiseSuppression: true,
+        }
+      });
+
+      const mediaRecorder = new MediaRecorder(stream);
+      mediaRecorderRef.current = mediaRecorder;
+      audioChunksRef.current = [];
+
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          audioChunksRef.current.push(event.data);
+        }
+      };
+
+      mediaRecorder.onstop = () => {
+        const audioBlob = new Blob(audioChunksRef.current, { type: 'audio/webm' });
+        setAudioBlob(audioBlob);
+        stream.getTracks().forEach(track => track.stop());
+      };
+
+      mediaRecorder.start();
+      setIsRecording(true);
+      setState({ status: 'recording' });
+    } catch (error) {
+      console.error('Error starting recording:', error);
+      setState({ status: 'error', error: 'Failed to access microphone' });
+    }
+  };
+
+  const stopRecording = () => {
+    if (mediaRecorderRef.current && mediaRecorderRef.current.state === 'recording') {
+      mediaRecorderRef.current.stop();
+      setIsRecording(false);
+    }
+  };
+
+  const processVoiceInput = async () => {
+    if (!audioBlob) {
+      setState({ status: 'error', error: 'No audio recorded' });
+      return;
+    }
+
+    setState({ status: 'transcribing' });
+    setAgentOutputs({});
+
+    try {
+      // Convert audio blob to base64
+      const arrayBuffer = await audioBlob.arrayBuffer();
+      const base64Audio = arrayBufferToBase64(arrayBuffer);
+
+      // Create task with audio data
+      const task = `audio_data: ${base64Audio.substring(0, 100)}...`;
+
+      setState({ status: 'processing' });
+
+      // Execute the voice conversation orchestration
+      // We'll use the sequential execution API
+      const agents = [
+        {
+          name: 'Voice Listener',
+          system_prompt: `You are a Voice Listener agent. Your job is to transcribe user audio input to text.
+
+CRITICAL TOOL USAGE:
+====================
+You have access to the voice-interaction MCP server with these tools:
+- mcp__voice-interaction__transcribe_audio
+- mcp__voice-interaction__synthesize_speech
+
+YOUR PRIMARY TASK:
+==================
+When you receive audio data, use the transcribe_audio tool:
+
+Tool: mcp__voice-interaction__transcribe_audio
+Args: {
+  "audio_data": "${base64Audio}"
+}
+
+Return the transcribed text clearly.`,
+          role: 'specialist',
+          use_tools: true
+        },
+        {
+          name: 'Conversation Handler',
+          system_prompt: `You are a Conversation Handler agent. You receive transcribed user input and generate helpful responses.
+
+YOUR ROLE:
+==========
+- Receive the transcribed text from the Voice Listener agent
+- Understand the user's request or question
+- Generate a clear, helpful, and conversational response
+- Keep responses concise (2-3 sentences max) for voice output
+
+Be conversational and natural, as this will be spoken aloud!`,
+          role: 'specialist',
+          use_tools: false
+        },
+        {
+          name: 'Voice Speaker',
+          system_prompt: `You are a Voice Speaker agent. Your job is to convert text responses into speech audio.
+
+CRITICAL TOOL USAGE:
+====================
+Use the synthesize_speech tool:
+
+Tool: mcp__voice-interaction__synthesize_speech
+Args: {
+  "text": "<text_from_previous_agent>"
+}
+
+Return the audio data that can be played in the browser.`,
+          role: 'specialist',
+          use_tools: true
+        }
+      ];
+
+      // Execute orchestration with streaming
+      let currentAgent = '';
+
+      await orchestrationApi.executeSequential(
+        agents.map((a, i) => ({ ...a, id: `agent-${i+1}` })),
+        task,
+        async (event: StreamEvent) => {
+          if (event.type === 'agent_start') {
+            currentAgent = event.agent_name;
+            setAgentOutputs(prev => ({ ...prev, [currentAgent]: '' }));
+          } else if (event.type === 'agent_output' && currentAgent) {
+            setAgentOutputs(prev => ({
+              ...prev,
+              [currentAgent]: (prev[currentAgent] || '') + event.data
+            }));
+
+            // Extract transcription and response
+            if (currentAgent === 'Voice Listener' && event.data) {
+              setState(prev => ({ ...prev, transcription: event.data }));
+            } else if (currentAgent === 'Conversation Handler' && event.data) {
+              setState(prev => ({ ...prev, response: event.data }));
+            } else if (currentAgent === 'Voice Speaker' && event.data) {
+              // Look for base64 audio data in the response
+              const audioMatch = event.data.match(/[A-Za-z0-9+/]{100,}={0,2}/);
+              if (audioMatch) {
+                setState(prev => ({ ...prev, audioData: audioMatch[0], status: 'synthesizing' }));
+              }
+            }
+          } else if (event.type === 'complete') {
+            setState(prev => ({ ...prev, status: 'completed' }));
+          } else if (event.type === 'error') {
+            setState({ status: 'error', error: event.error });
+          }
+        }
+      );
+
+    } catch (error: any) {
+      console.error('Error processing voice input:', error);
+      setState({ status: 'error', error: error.message || 'Failed to process voice input' });
+    }
+  };
+
+  const playAudio = () => {
+    if (!state.audioData) return;
+
+    try {
+      // Convert base64 to audio blob
+      const byteCharacters = atob(state.audioData);
+      const byteNumbers = new Array(byteCharacters.length);
+      for (let i = 0; i < byteCharacters.length; i++) {
+        byteNumbers[i] = byteCharacters.charCodeAt(i);
+      }
+      const byteArray = new Uint8Array(byteNumbers);
+      const blob = new Blob([byteArray], { type: 'audio/wav' });
+
+      const audioUrl = URL.createObjectURL(blob);
+
+      if (!audioElementRef.current) {
+        audioElementRef.current = new Audio();
+      }
+
+      const audio = audioElementRef.current;
+      audio.src = audioUrl;
+
+      audio.onended = () => {
+        URL.revokeObjectURL(audioUrl);
+        setState(prev => ({ ...prev, status: 'completed' }));
+      };
+
+      audio.onerror = () => {
+        URL.revokeObjectURL(audioUrl);
+        setState({ ...state, status: 'error', error: 'Failed to play audio' });
+      };
+
+      audio.play();
+      setState(prev => ({ ...prev, status: 'playing' }));
+    } catch (error) {
+      console.error('Error playing audio:', error);
+      setState({ ...state, status: 'error', error: 'Failed to play audio' });
+    }
+  };
+
+  const reset = () => {
+    setState({ status: 'idle' });
+    setAudioBlob(null);
+    setAgentOutputs({});
+    if (audioElementRef.current) {
+      audioElementRef.current.pause();
+      audioElementRef.current = null;
+    }
+  };
+
+  const getActiveStep = () => {
+    switch (state.status) {
+      case 'idle':
+      case 'recording':
+        return 0;
+      case 'transcribing':
+      case 'processing':
+        return 1;
+      case 'synthesizing':
+        return 2;
+      case 'playing':
+      case 'completed':
+        return 3;
+      default:
+        return 0;
+    }
+  };
+
+  return (
+    <Box sx={{ p: 3, maxWidth: 1200, mx: 'auto' }}>
+      {/* Header */}
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h4" gutterBottom>
+          🎤 Voice Conversation Demo
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Demonstrates voice MCP integration: Listen → Think → Speak
+        </Typography>
+      </Box>
+
+      {/* Progress Steps */}
+      <Paper sx={{ p: 3, mb: 3 }}>
+        <Stepper activeStep={getActiveStep()} alternativeLabel>
+          <Step>
+            <StepLabel>Record Voice</StepLabel>
+          </Step>
+          <Step>
+            <StepLabel>Transcribe & Process</StepLabel>
+          </Step>
+          <Step>
+            <StepLabel>Synthesize Speech</StepLabel>
+          </Step>
+          <Step>
+            <StepLabel>Play Response</StepLabel>
+          </Step>
+        </Stepper>
+      </Paper>
+
+      {/* Recording Controls */}
+      <Paper sx={{ p: 3, mb: 3, textAlign: 'center' }}>
+        {state.status === 'idle' || state.status === 'recording' ? (
+          <Box>
+            <IconButton
+              onClick={isRecording ? stopRecording : startRecording}
+              disabled={state.status !== 'idle' && state.status !== 'recording'}
+              sx={{
+                width: 100,
+                height: 100,
+                bgcolor: isRecording ? 'error.main' : 'primary.main',
+                color: 'white',
+                '&:hover': {
+                  bgcolor: isRecording ? 'error.dark' : 'primary.dark',
+                },
+                mb: 2,
+              }}
+            >
+              {isRecording ? <MicOff sx={{ fontSize: 48 }} /> : <Mic sx={{ fontSize: 48 }} />}
+            </IconButton>
+            <Typography variant="h6" gutterBottom>
+              {isRecording ? 'Recording... Click to Stop' : 'Click to Start Recording'}
+            </Typography>
+            {audioBlob && !isRecording && (
+              <Button
+                variant="contained"
+                startIcon={<PlayArrow />}
+                onClick={processVoiceInput}
+                size="large"
+                sx={{ mt: 2 }}
+              >
+                Process Voice Input
+              </Button>
+            )}
+          </Box>
+        ) : state.status === 'error' ? (
+          <Box>
+            <ErrorIcon sx={{ fontSize: 64, color: 'error.main', mb: 2 }} />
+            <Typography variant="h6" color="error" gutterBottom>
+              Error
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              {state.error}
+            </Typography>
+            <Button
+              variant="outlined"
+              startIcon={<Refresh />}
+              onClick={reset}
+            >
+              Try Again
+            </Button>
+          </Box>
+        ) : (
+          <Box>
+            <CircularProgress size={80} sx={{ mb: 2 }} />
+            <Typography variant="h6">
+              {state.status === 'transcribing' && 'Transcribing audio...'}
+              {state.status === 'processing' && 'Processing your request...'}
+              {state.status === 'synthesizing' && 'Synthesizing speech...'}
+              {state.status === 'playing' && 'Playing response...'}
+              {state.status === 'completed' && 'Completed!'}
+            </Typography>
+          </Box>
+        )}
+      </Paper>
+
+      {/* Results */}
+      {(state.transcription || state.response || state.audioData) && (
+        <Box sx={{ display: 'grid', gap: 2 }}>
+          {/* Transcription */}
+          {state.transcription && (
+            <Card>
+              <CardContent>
+                <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+                  <Mic sx={{ mr: 1, color: 'primary.main' }} />
+                  <Typography variant="h6">Transcription</Typography>
+                  <Chip label="Step 1" size="small" sx={{ ml: 'auto' }} />
+                </Box>
+                <Divider sx={{ mb: 2 }} />
+                <Typography variant="body1">{state.transcription}</Typography>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Response */}
+          {state.response && (
+            <Card>
+              <CardContent>
+                <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+                  <CheckCircle sx={{ mr: 1, color: 'success.main' }} />
+                  <Typography variant="h6">AI Response</Typography>
+                  <Chip label="Step 2" size="small" sx={{ ml: 'auto' }} />
+                </Box>
+                <Divider sx={{ mb: 2 }} />
+                <Typography variant="body1">{state.response}</Typography>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Audio Playback */}
+          {state.audioData && (
+            <Card>
+              <CardContent>
+                <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+                  <VolumeUp sx={{ mr: 1, color: 'secondary.main' }} />
+                  <Typography variant="h6">Synthesized Speech</Typography>
+                  <Chip label="Step 3" size="small" sx={{ ml: 'auto' }} />
+                </Box>
+                <Divider sx={{ mb: 2 }} />
+                <Box sx={{ textAlign: 'center' }}>
+                  <Button
+                    variant="contained"
+                    startIcon={<VolumeUp />}
+                    onClick={playAudio}
+                    disabled={state.status === 'playing'}
+                    size="large"
+                  >
+                    {state.status === 'playing' ? 'Playing...' : 'Play Audio Response'}
+                  </Button>
+                </Box>
+              </CardContent>
+            </Card>
+          )}
+        </Box>
+      )}
+
+      {/* Agent Outputs Debug */}
+      {Object.keys(agentOutputs).length > 0 && (
+        <Paper sx={{ p: 2, mt: 3, bgcolor: 'rgba(0, 0, 0, 0.3)' }}>
+          <Typography variant="caption" color="text.secondary" gutterBottom display="block">
+            Agent Outputs (Debug)
+          </Typography>
+          {Object.entries(agentOutputs).map(([agent, output]) => (
+            <Box key={agent} sx={{ mb: 1 }}>
+              <Typography variant="caption" fontWeight="bold">
+                {agent}:
+              </Typography>
+              <Typography variant="caption" sx={{ ml: 1, fontFamily: 'monospace', fontSize: 10 }}>
+                {output.substring(0, 200)}{output.length > 200 ? '...' : ''}
+              </Typography>
+            </Box>
+          ))}
+        </Paper>
+      )}
+
+      {/* Reset Button */}
+      {state.status === 'completed' && (
+        <Box sx={{ textAlign: 'center', mt: 3 }}>
+          <Button
+            variant="outlined"
+            startIcon={<Refresh />}
+            onClick={reset}
+            size="large"
+          >
+            Start New Conversation
+          </Button>
+        </Box>
+      )}
+
+      {/* Info Alert */}
+      <Alert severity="info" sx={{ mt: 3 }}>
+        <Typography variant="body2">
+          This demo showcases the voice MCP integration with Claude agents.
+          The Voice Listener agent uses <code>mcp__voice-interaction__transcribe_audio</code> to transcribe your speech,
+          the Conversation Handler processes your request,
+          and the Voice Speaker agent uses <code>mcp__voice-interaction__synthesize_speech</code> to respond with audio.
+        </Typography>
+      </Alert>
+    </Box>
+  );
+};
+
+export default VoiceDemoPage;


### PR DESCRIPTION
## Summary

This PR adds a complete demonstration of voice MCP integration, showcasing how Claude agents can autonomously use voice tools (transcribe_audio and synthesize_speech) via the Model Context Protocol.

## What's New

### 1. Voice Conversation Orchestration Design
- **New seed design**: "Voice Conversation Assistant" (Design #13)
- **3-agent sequential pipeline**:
  - Voice Listener: Uses `mcp__voice-interaction__transcribe_audio` to convert speech to text
  - Conversation Handler: Processes transcribed text and generates conversational responses
  - Voice Speaker: Uses `mcp__voice-interaction__synthesize_speech` to convert text to speech
- Complete Listen → Think → Speak workflow

### 2. Voice Demo UI Page
- **New route**: `/voice-demo` with microphone icon in navigation
- **Features**:
  - Microphone recording interface with visual feedback
  - 4-step progress stepper (Record → Transcribe → Synthesize → Play)
  - Real-time agent output display
  - Audio playback of synthesized responses
  - Error handling and reset functionality
  - Debug panel showing agent execution

### 3. Integration
- Added to seed orchestration designs (can be loaded in Orchestration Designer)
- Integrated with navigation bar and routing
- Ready for deployment and execution

## Technical Details

**Files Changed:**
- `backend/seed_voice_conversation_design.py` - New seed design definition
- `backend/seed_orchestration_designs.py` - Added voice design to seed list
- `frontend/src/components/VoiceDemoPage.tsx` - New demo UI component
- `frontend/src/App.tsx` - Added route for voice demo
- `frontend/src/components/ModernLayout.tsx` - Added navigation item

**Agent Prompts:**
All agents include detailed system prompts with:
- Explicit MCP tool names (e.g., `mcp__voice-interaction__transcribe_audio`)
- Clear workflows and examples
- Expected input/output formats

## Key Difference: MCP vs Direct API

**Before (Direct API)**:
```
Frontend → Voice Backend (14300) → Transcription
```
Agents unaware of voice capabilities

**After (MCP Integration)**:
```
Frontend → Claude Agent
    ↓
Agent decides: "I need voice tools"
    ↓
MCP: mcp__voice-interaction__transcribe_audio
    ↓
Voice MCP Server (14302) → Voice Backend (14300)
    ↓
Agent processes transcription
    ↓
Agent decides to synthesize response
    ↓
MCP: mcp__voice-interaction__synthesize_speech
    ↓
Audio returns to frontend
```
**Claude controls when and how to use voice!**

## How to Use

1. **Seed the design**:
   ```bash
   python backend/seed_orchestration_designs.py
   ```

2. **Ensure voice MCP server is configured** in `agent_orchestrator.py`:
   ```python
   mcp_servers={
       "workflow-manager": {...},
       "voice-interaction": {
           "type": "http",
           "url": "http://voice-mcp-server-http:8001/mcp"
       }
   }
   ```

3. **Start voice services**:
   ```bash
   docker compose -f docker-compose.yml -f docker-compose.voice.yml up -d
   ```

4. **Access the demo** at `/voice-demo` (microphone icon in nav bar)

## Testing

- ✅ Created seed design successfully
- ✅ UI component renders correctly
- ✅ Navigation integration working
- ✅ Route properly configured
- ⚠️ Full end-to-end test requires voice MCP server configuration

## Benefits

1. **Demonstrates MCP Integration**: Shows proper use of MCP tools by agents
2. **Educational**: Clear example of voice-enabled agent orchestration
3. **Reusable**: Voice agents can be combined with other patterns
4. **Extensible**: Foundation for more complex voice workflows

## Next Steps

- Configure voice MCP server in agent orchestration options
- Test complete flow with live voice input
- Expand to more complex multi-modal workflows
- Document voice MCP usage patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)