### PR TITLE
Fix: Add Image and Voice MCP tools to allowed_tools whitelist

### DIFF
--- a/claude-workflow-manager/backend/agent_orchestrator.py
+++ b/claude-workflow-manager/backend/agent_orchestrator.py
@@ -361,11 +361,22 @@ class MultiAgentOrchestrator:
                     }
                 },
                 allowed_tools=[
+                    # Workflow Manager tools
                     "mcp__workflow-manager__editor_browse_directory",
                     "mcp__workflow-manager__editor_read_file",
                     "mcp__workflow-manager__editor_create_change",
                     "mcp__workflow-manager__editor_get_changes",
-                    "mcp__workflow-manager__editor_search_files"
+                    "mcp__workflow-manager__editor_search_files",
+                    # Image Processing tools
+                    "mcp__image-processing__extract_text_from_image",
+                    "mcp__image-processing__extract_text_from_url",
+                    "mcp__image-processing__extract_text_from_pdf",
+                    "mcp__image-processing__check_image_api_health",
+                    # Voice Interaction tools
+                    "mcp__voice-interaction__transcribe_audio",
+                    "mcp__voice-interaction__synthesize_speech",
+                    "mcp__voice-interaction__voice_conversation",
+                    "mcp__voice-interaction__check_voice_api_health"
                 ],
                 max_turns=10
             )


### PR DESCRIPTION
## Summary

Fixes the final MCP integration issue preventing Image OCR and Voice interaction demos from working. The agent orchestrator now allows access to all image-processing and voice-interaction MCP tools.

## Problem

The MCP servers were successfully connected and responding with `200 OK`, but agents were unable to call the tools because they weren't included in the `allowed_tools` whitelist. The whitelist only contained workflow-manager tools.

## Solution

Added all image-processing and voice-interaction MCP tools to the `allowed_tools` list in agent orchestrator:

**Image Processing Tools:**
- `mcp__image-processing__extract_text_from_image`
- `mcp__image-processing__extract_text_from_url`
- `mcp__image-processing__extract_text_from_pdf`
- `mcp__image-processing__check_image_api_health`

**Voice Interaction Tools:**
- `mcp__voice-interaction__transcribe_audio`
- `mcp__voice-interaction__synthesize_speech`
- `mcp__voice-interaction__voice_conversation`
- `mcp__voice-interaction__check_voice_api_health`

## Testing

This completes the MCP demo implementation:
- Image Demo Page (PR #444) - Document OCR with drag-drop upload
- Voice Demo Page (PR #442) - Voice transcription and synthesis

## Files Changed

- `claude-workflow-manager/backend/agent_orchestrator.py` - Added tools to allowed_tools list

## Related PRs

- PR #442: Voice Demo implementation
- PR #444: Image Demo implementation